### PR TITLE
Add Data.TaggedEnum example to taggedEnum JSDoc

### DIFF
--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -438,6 +438,20 @@ export declare namespace TaggedEnum {
  * ```
  *
  * @example
+ * ```ts
+ * import { Data } from "effect"
+ *
+ * type HttpError = Data.TaggedEnum<{
+ *   BadRequest: { readonly status: 400; readonly message: string }
+ *   NotFound: { readonly status: 404; readonly message: string }
+ * }>
+ *
+ * const { BadRequest, NotFound } = Data.taggedEnum<HttpError>()
+ *
+ * const notFound = NotFound({ status: 404, message: "Not Found" })
+ * ```
+ *
+ * @example
  * import { Data } from "effect"
  *
  * type MyResult<E, A> = Data.TaggedEnum<{


### PR DESCRIPTION
## Summary
- Adds a missing `@example` to the `Data.taggedEnum` constructor showing the common pattern of using `Data.TaggedEnum<{...}>` as the type parameter
- The existing JSDoc only showed the verbose union syntax (with explicit `_tag`) and the generics case, but not the simplest and most common usage

Based on this conversation: https://discord.com/channels/795981131316985866/1486327719217201252

