### PR TITLE
Add GitHub Action to keep fork in sync with upstream

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,40 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    # Runs every 6 hours
+    - cron: "0 */6 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync fork with upstream
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Get default branch
+            const { data: repoData } = await github.rest.repos.get({ owner, repo });
+            const defaultBranch = repoData.default_branch;
+
+            try {
+              const result = await github.rest.repos.mergeUpstream({
+                owner,
+                repo,
+                branch: defaultBranch,
+              });
+              core.info(`Sync result: ${result.data.message}`);
+            } catch (error) {
+              if (error.status === 409) {
+                core.info('No new commits to sync — fork is already up to date.');
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
Runs every 6 hours (and on manual trigger) using GitHub's
built-in merge-upstream API to pull new commits from the
upstream repository into the fork's default branch.

https://claude.ai/code/session_01DxrkKTpqZE3H4ygdveirxL